### PR TITLE
Code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: elixir
 sudo: required
 services: docker
+env:
+  - NEO4J_VERSION=3.0
+  - NEO4J_VERSION=3.1
 elixir:
   - 1.3
+  - 1.4
 before_install:
-  - docker run --name neo4j -d -p 7687:7687 -e 'NEO4J_AUTH=neo4j/password' neo4j:3.0.6
+  - docker run --name neo4j -d -p 7687:7687 -e 'NEO4J_AUTH=neo4j/password' neo4j:$NEO4J_VERSION
   - docker logs -f neo4j | sed /Bolt\ enabled/q
 script: mix coveralls.travis

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Boltex
 [![Build Status](https://travis-ci.org/mschae/boltex.svg?branch=master)](https://travis-ci.org/mschae/boltex)
 [![Inline docs](http://inch-ci.org/github/mschae/boltex.svg?branch=master)](http://inch-ci.org/github/mschae/boltex)
-
+[![Coverage Status](https://coveralls.io/repos/github/mschae/boltex/badge.svg?branch=master)](https://coveralls.io/github/mschae/boltex?branch=master)
 
 Elixir implementation of the Bolt protocol and corresponding PackStream
 protocol. Both is being used by Neo4J.

--- a/lib/boltex/error.ex
+++ b/lib/boltex/error.ex
@@ -62,6 +62,12 @@ defmodule Boltex.Error do
       other                 -> other
     end
   end
+  defp message_for(_function, {:ignored, []}) do
+    """
+    The session is in a failed state and ignores further messages. You need to
+    `ACK_FAILURE` or `RESET` in order to send new messages.
+    """
+  end
   defp message_for(function, message) do
     """
     #{function}: Unknown failure: #{inspect message}

--- a/lib/boltex/pack_stream.ex
+++ b/lib/boltex/pack_stream.ex
@@ -55,28 +55,12 @@ defmodule Boltex.PackStream do
   def decode(<< 0xD4,     list_size :: 8  >> <> bin), do: list(bin, list_size)
   def decode(<< 0xD5,     list_size :: 16 >> <> bin), do: list(bin, list_size)
   def decode(<< 0xD6,     list_size :: 32 >> <> bin), do: list(bin, list_size)
-  def decode(<< 0xD7 >> <> bin) do
-    bytes    = for(<< byte <- bin >>, do: byte)
-    position = Enum.find_index bytes, &(&1 == 0xDF)
-
-    << list :: binary-size(position), 0xDF, rest :: binary >> = bin
-
-    [decode(list) | decode(rest)]
-  end
 
   # Maps
   def decode(<< 0xA :: 4, entries :: 4 >>  <> bin), do: map(bin, entries)
   def decode(<< 0xD8,     entries :: 8 >>  <> bin), do: map(bin, entries)
   def decode(<< 0xD9,     entries :: 16 >> <> bin), do: map(bin, entries)
   def decode(<< 0xDA,     entries :: 32 >> <> bin), do: map(bin, entries)
-  def decode(<< 0xDB >> <> bin) do
-    bytes    = for(<< byte <- bin >>, do: byte)
-    position = Enum.find_index bytes, &(&1 == 0xDF)
-
-    << map :: binary-size(position), 0xDF, rest :: binary >> = bin
-
-    [(map |> decode |> to_map)] ++ decode(rest)
-  end
 
   # Struct
   def decode(<< 0xB :: 4, struct_size :: 4, sig :: 8 >> <> struct) do

--- a/lib/boltex/pack_stream.ex
+++ b/lib/boltex/pack_stream.ex
@@ -79,7 +79,17 @@ defmodule Boltex.PackStream do
   end
 
   # Struct
-  def decode(<< 0xB :: 4, struct_size :: 4, sig :: 8>> <> struct) do
+  def decode(<< 0xB :: 4, struct_size :: 4, sig :: 8 >> <> struct) do
+    {struct, rest} = struct |> decode |> Enum.split(struct_size)
+
+    [[sig: sig, fields: struct] | rest]
+  end
+  def decode(<< 0xDC, struct_size :: 8, sig :: 8 >> <> struct) do
+    {struct, rest} = struct |> decode |> Enum.split(struct_size)
+
+    [[sig: sig, fields: struct] | rest]
+  end
+  def decode(<< 0xDD, struct_size :: 16, sig :: 8 >> <> struct) do
     {struct, rest} = struct |> decode |> Enum.split(struct_size)
 
     [[sig: sig, fields: struct] | rest]

--- a/lib/boltex/pack_stream/encoder.ex
+++ b/lib/boltex/pack_stream/encoder.ex
@@ -85,9 +85,6 @@ defimpl Boltex.PackStream.Encoder, for: List do
   defp do_encode(binary, list_size) when list_size <= 4_294_967_295 do
     << 0xD6, list_size :: 32 >> <> binary
   end
-  defp do_encode(binary, _size) do
-    << 0xD7 >> <> binary <> <<0xDF>>
-  end
 end
 
 defimpl Boltex.PackStream.Encoder, for: Map do

--- a/test/boltex/bolt_test.exs
+++ b/test/boltex/bolt_test.exs
@@ -44,16 +44,8 @@ defmodule Boltex.BoltTest do
     assert [{:success, _} | _]                = Bolt.run_statement :gen_tcp, port, "RETURN 1 as num"
   end
 
-  test "returns proper error when using a bad session", %{port: port} do
-    assert %Boltex.Error{type: :cypher_error} = Bolt.run_statement :gen_tcp, port, "What?"
-    error = Bolt.run_statement :gen_tcp, port, "RETURN 1 as num"
-
-    assert %Boltex.Error{} = error
-    assert error.message   =~ ~r/The session is in a failed state/
-  end
-
   test "returns proper error when misusing ack_failure and reset", %{port: port} do
-    assert %Boltex.Error{} = Bolt.ack_failure :gen_tcp, port
+    assert {:failure, _} = Bolt.ack_failure :gen_tcp, port
     :gen_tcp.close port
     assert %Boltex.Error{} = Bolt.reset :gen_tcp, port
   end

--- a/test/boltex/bolt_test.exs
+++ b/test/boltex/bolt_test.exs
@@ -1,52 +1,46 @@
-defmodule BoltexTest do
+defmodule Boltex.BoltTest do
   use Boltex.IntegrationCase
   alias Boltex.Bolt
 
-  doctest Boltex
-
   test "works for small queries", %{port: port} do
+    string = Enum.to_list(0..100) |> Enum.join()
     query = """
-      UNWIND {largeRange} as i
-      RETURN i
+      RETURN {string} as string
     """
 
-    params = %{largeRange: Enum.to_list(0..100)}
+    params = %{string: string}
 
     [{:success, _} | records] = Bolt.run_statement :gen_tcp, port, query, params
 
-    numbers =
-      records
-      |> List.delete_at(-1)
-      |> Enum.map(fn({:record, [number]}) -> number end)
-
-    assert numbers == Enum.to_list(0..100)
+    assert [record: [^string], success: _] = records
   end
 
   test "works for big queries", %{port: port} do
+    string = Enum.to_list(0..25_000) |> Enum.join()
     query = """
-      UNWIND {largeRange} as i
-      RETURN i
+      RETURN {string} as string
     """
 
-    params = %{largeRange: Enum.to_list(0..25_000)}
+    params = %{string: string}
 
     [{:success, _} | records] = Bolt.run_statement :gen_tcp, port, query, params
 
-    numbers =
-      records
-      |> List.delete_at(-1)
-      |> Enum.map(fn({:record, [number]}) -> number end)
-
-    assert numbers == Enum.to_list(0..25_000)
+    assert [record: [^string], success: _] = records
   end
 
   test "returns errors for wrong cypher queris", %{port: port} do
     assert %Boltex.Error{type: :cypher_error} = Bolt.run_statement :gen_tcp, port, "What?"
   end
 
-  test "allows to recover from error", %{port: port} do
+  test "allows to recover from error with ack_failure", %{port: port} do
     assert %Boltex.Error{type: :cypher_error} = Bolt.run_statement :gen_tcp, port, "What?"
-    assert :ok                                = Bolt.ack_failure :gen_tcp, port, []
+    assert :ok                                = Bolt.ack_failure :gen_tcp, port
+    assert [{:success, _} | _]                = Bolt.run_statement :gen_tcp, port, "RETURN 1 as num"
+  end
+
+  test "allows to recover from error with reset", %{port: port} do
+    assert %Boltex.Error{type: :cypher_error} = Bolt.run_statement :gen_tcp, port, "What?"
+    assert :ok                                = Bolt.reset :gen_tcp, port
     assert [{:success, _} | _]                = Bolt.run_statement :gen_tcp, port, "RETURN 1 as num"
   end
 
@@ -55,6 +49,18 @@ defmodule BoltexTest do
     error = Bolt.run_statement :gen_tcp, port, "RETURN 1 as num"
 
     assert %Boltex.Error{} = error
-    assert error.message   =~ ~r/'ACK_FAILURE'/
+    assert error.message   =~ ~r/The session is in a failed state/
+  end
+
+  test "returns proper error when misusing ack_failure and reset", %{port: port} do
+    assert %Boltex.Error{} = Bolt.ack_failure :gen_tcp, port
+    :gen_tcp.close port
+    assert %Boltex.Error{} = Bolt.reset :gen_tcp, port
+  end
+
+  test "returns proper error when using a closed port", %{port: port} do
+    :gen_tcp.close port
+
+    assert %Boltex.Error{type: :connection_error} = Bolt.run_statement :gen_tcp, port, "RETURN 1 as num"
   end
 end

--- a/test/boltex/pack_stream_test.exs
+++ b/test/boltex/pack_stream_test.exs
@@ -75,6 +75,15 @@ defmodule Boltex.PackStreamTest do
 
   test "encodes map" do
     assert PackStream.encode(%{}) == <<0xA0>>
+
+    map_8 = 1..16 |> Enum.map(&{&1, "a"}) |> Map.new
+    assert <<0xD8, 16 :: 8 >> <> _rest = PackStream.encode(map_8)
+
+    map_16 = 1..256 |> Enum.map(&{&1, "a"}) |> Map.new
+    assert <<0xD9, 256 :: 16 >> <> _rest = PackStream.encode(map_16)
+
+    map_32 = 1..66_000 |> Enum.map(&{&1, "a"}) |> Map.new
+    assert <<0xDA, 256 :: 32 >> <> _rest = PackStream.encode(map_16)
   end
 
   test "encodes a struct" do
@@ -82,7 +91,7 @@ defmodule Boltex.PackStreamTest do
   end
 
   test "raises an error when trying to encode something we don't know" do
-    assert_raise Boltex.PackStream.EncodeError, fn ->
+    assert_raise Boltex.PackStream.EncodeError, "unable to encode value: {:tuple}", fn ->
       PackStream.encode({:tuple})
     end
   end
@@ -157,9 +166,5 @@ defmodule Boltex.PackStreamTest do
     assert PackStream.decode(<<0xAB, 0x81, 0x61, 0x01>>) == [%{"a" => 1}]
     assert PackStream.decode(<<0xDB, 0x81, 0x61, 0x01, 0xDF>>) == [%{"a" => 1}]
     assert PackStream.decode(big_map) == [%{"a" => 1,"b" => 1,"c" => 3,"d" => 4,"e" => 5,"f" => 6,"g" => 7,"h" => 8,"i" => 9,"j" => 0,"k" => 1,"l" => 2,"m" => 3,"n" => 4,"o" => 5,"p" => 6}]
-
-  end
-
-  test "decodes big maps" do
   end
 end

--- a/test/boltex/pack_stream_test.exs
+++ b/test/boltex/pack_stream_test.exs
@@ -83,7 +83,7 @@ defmodule Boltex.PackStreamTest do
     assert <<0xD9, 256 :: 16 >> <> _rest = PackStream.encode(map_16)
 
     map_32 = 1..66_000 |> Enum.map(&{&1, "a"}) |> Map.new
-    assert <<0xDA, 256 :: 32 >> <> _rest = PackStream.encode(map_16)
+    assert <<0xDA, 66_000 :: 32 >> <> _rest = PackStream.encode(map_32)
   end
 
   test "encodes a struct" do

--- a/test/boltex/utils_test.exs
+++ b/test/boltex/utils_test.exs
@@ -1,0 +1,9 @@
+defmodule Boltex.UtilsTest do
+  use ExUnit.Case
+
+  alias Boltex.Utils
+
+  test "encodes bytes to hex" do
+    assert ~w(7B 7C) == Utils.hex_encode(<<123, 124>>)
+  end
+end

--- a/test/boltex_test.exs
+++ b/test/boltex_test.exs
@@ -1,0 +1,8 @@
+defmodule BoltexTest do
+  use ExUnit.Case
+
+  test "it works" do
+    uri = Boltex.IntegrationCase.neo4j_uri
+    Boltex.test uri.host, uri.port, "RETURN 1 as num", %{}, uri.userinfo
+  end
+end


### PR DESCRIPTION
Hey @florinpatrascu,

this PR changes the return value when structs (such as nodes, relationships) are returned.

Formerly a struct would just be `[sig: <signature>, fields: <fields>]`. Now I changed it to return one of `Boltex.Struct`s, e.g. `%Boltex.Struct.Node{id: <id>, labels: <labels>, properties: <properties>}`. Regular (/unknown) structures will just be `%Boltex.Struct.Generic{signature: <signature>, fields: <fields>}`.

This is still WIP (I'm going to add the two remaining documented struct types and renume from the current `Boltex.Structs` to `Boltex.Struct` but I wanted to discuss if that change is ok with you. If the new structs are a dealbreaker I can easily roll that back. The late addition was caused that only now is it properly [documented in the bolt procotol](http://boltprotocol.org/v1/#structures), at which point I wanted to turn it into proper data structures.

Other than that I improved `run_statement` so that it stops as soon as it detects an error (formerly it would still send the `PULL ALL` message, resulting in an `:ignored` by the server. I adjusted `ack_failure` (and the newly added `cancel`) accordingly, so it _should_ not need any changes on your end.

Let me know!

Thanks, Michael