### PR TITLE
Fix decoding problem with trailing 0x00

### DIFF
--- a/lib/boltex/pack_stream.ex
+++ b/lib/boltex/pack_stream.ex
@@ -84,7 +84,6 @@ defmodule Boltex.PackStream do
     [[sig: sig, fields: struct] | rest]
   end
 
-  def decode(<<0, 0>>), do: []
   def decode(""), do: []
 
   # Integers

--- a/test/boltex/pack_stream_test.exs
+++ b/test/boltex/pack_stream_test.exs
@@ -165,6 +165,9 @@ defmodule Boltex.PackStreamTest do
 
     list_32 = <<0xD6, 66_000::32>> <> (1..66_000 |> Enum.map(&PackStream.encode/1) |> Enum.join())
     assert PackStream.decode(list_32) == [1..66_000 |> Enum.to_list()]
+
+    ending_0_list = <<0x93, 0x91, 0x1, 0x92, 0x2, 0x0, 0x0>>
+    assert PackStream.decode(ending_0_list) == [[[1], [2, 0], 0]]
   end
 
   test "decodes maps" do


### PR DESCRIPTION
Trailing <<0x00>> are consider non-value but they can be the end of a list.
